### PR TITLE
Feature: Add Clipboard Paste Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Here's the list of available XML attributes:
 - `scv_symbolBorderActiveColor`: color to use for symbol subview's stroke outline for an active symbol. Default value = `scv_symbolBorderColor`.
 - `scv_symbolBorderWidth`: thickness of the stroke used to draw symbol subview's border. Default value = [2dp](https://github.com/fraggjkee/SmsConfirmationView/blob/fb2be87c0510a10a95b343f79380de72f6fe7742/library/src/main/res/values/dimens.xml#L9)
 - `scv_symbolBorderCornerRadius`: corner radius for symbol subview's border. Default value = [2dp](https://github.com/fraggjkee/SmsConfirmationView/blob/fb2be87c0510a10a95b343f79380de72f6fe7742/library/src/main/res/values/dimens.xml#L5)
+- `scv_allowCodePaste`: corner radius for symbol subview's border. Default value = `true`.
 
 All of these attributes can also be changed **programatically** (XML customization is the preferred way though), check out the list of available extensions [here](https://github.com/fraggjkee/SmsConfirmationView/blob/master/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewExt.kt).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Here's the list of available XML attributes:
 - `scv_symbolBorderActiveColor`: color to use for symbol subview's stroke outline for an active symbol. Default value = `scv_symbolBorderColor`.
 - `scv_symbolBorderWidth`: thickness of the stroke used to draw symbol subview's border. Default value = [2dp](https://github.com/fraggjkee/SmsConfirmationView/blob/fb2be87c0510a10a95b343f79380de72f6fe7742/library/src/main/res/values/dimens.xml#L9)
 - `scv_symbolBorderCornerRadius`: corner radius for symbol subview's border. Default value = [2dp](https://github.com/fraggjkee/SmsConfirmationView/blob/fb2be87c0510a10a95b343f79380de72f6fe7742/library/src/main/res/values/dimens.xml#L5)
-- `scv_allowCodePaste`: corner radius for symbol subview's border. Default value = `true`.
+- `scv_allowCodePaste`: controls whether the user can paste from their keyboard into the view. Default value = `true`.
 
 All of these attributes can also be changed **programatically** (XML customization is the preferred way though), check out the list of available extensions [here](https://github.com/fraggjkee/SmsConfirmationView/blob/master/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewExt.kt).
 

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/AndroidExtensions.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/AndroidExtensions.kt
@@ -8,6 +8,8 @@ import android.view.inputmethod.InputMethodManager
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.color.MaterialColors
 
 @ColorInt
@@ -17,7 +19,12 @@ internal fun Context.getThemeColor(@AttrRes attrRes: Int): Int {
 
 internal fun View.showKeyboard() {
     val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    imm.showSoftInput(this, InputMethodManager.SHOW_FORCED)
+    imm.showSoftInput(this, 0)
+}
+
+internal fun View.isKeyboardOpen(): Boolean {
+    return ViewCompat.getRootWindowInsets(this)
+        ?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
 }
 
 internal fun View.hideKeyboard() {

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
@@ -203,7 +203,7 @@ class SmsConfirmationView @JvmOverloads constructor(
 
     private fun appendPaste(pastedInput: String) {
         pastedInput.forEach { char ->
-            // Piggy-back onto `appendSymbol`
+            // Piggy-back onto `appendSymbol` as it guards code length
             appendSymbol(char)
         }
     }

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
@@ -307,7 +307,8 @@ class SmsConfirmationView @JvmOverloads constructor(
         val codeLength: Int,
         val symbolsSpacing: Int,
         val symbolViewStyle: SymbolView.Style,
-        val smsDetectionMode: SmsDetectionMode = SmsDetectionMode.AUTO
+        val smsDetectionMode: SmsDetectionMode = SmsDetectionMode.AUTO,
+        val allowCodePaste: Boolean
     )
 
     internal enum class SmsDetectionMode {

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
@@ -115,7 +115,6 @@ class SmsConfirmationView @JvmOverloads constructor(
     // Used to inflate and return the popup paste menu
     private fun initPasteMenu() : PopupMenu {
         val clipboard = getSystemService(context, ClipboardManager::class.java)
-        var pasteData = ""
         val pasteMenu = PopupMenu(this.context, this).apply {
             inflate(R.menu.popup_menu_paste)
             setOnMenuItemClickListener { menuItem ->
@@ -127,7 +126,7 @@ class SmsConfirmationView @JvmOverloads constructor(
                         val item = clipboard?.primaryClip?.getItemAt(0)
 
                         // Get the clipboard item text.
-                        pasteData = item?.text?.toString() ?: ""
+                        val pasteData = item?.text?.toString() ?: ""
 
                         // Paste the text into the component
                         appendPaste(pasteData)

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt
@@ -162,7 +162,16 @@ class SmsConfirmationView @JvmOverloads constructor(
         }
     }
 
+    // TODO (BA, 5/18/23): `ACTION_MULTIPLE`/`event.characters` deprecated
+    //  in API 29 noting "No longer used by the input system", though still working on API 33
+    //  and without alternatives from Google.
+    @Suppress("DEPRECATION")
     private fun handleKeyEvent(keyCode: Int, event: KeyEvent): Boolean = when {
+        event.action == KeyEvent.ACTION_MULTIPLE && event.keyCode == KeyEvent.KEYCODE_UNKNOWN && allowCodePaste -> {
+            val pastedInput = event.characters
+            appendPaste(pastedInput)
+            true
+        }
         event.action != KeyEvent.ACTION_DOWN -> false
         event.isDigitKey() -> {
             val enteredSymbol = event.keyCharacterMap.getNumber(keyCode)
@@ -190,6 +199,13 @@ class SmsConfirmationView @JvmOverloads constructor(
         }
 
         this.enteredCode = enteredCode + symbol
+    }
+
+    private fun appendPaste(pastedInput: String) {
+        pastedInput.forEach { char ->
+            // Piggy-back onto `appendSymbol`
+            appendSymbol(char)
+        }
     }
 
     private fun removeLastSymbol() {

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewExt.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewExt.kt
@@ -140,3 +140,12 @@ var SmsConfirmationView.symbolBorderCornerRadius: Float
         this.style = style.copy(symbolViewStyle = updatedStyle)
     }
     get() = style.symbolViewStyle.borderCornerRadius
+
+/**
+ * @see R.styleable.SmsConfirmationView_scv_allowCodePaste
+ */
+var SmsConfirmationView.allowCodePaste: Boolean
+    set(value) {
+        this.style = style.copy(allowCodePaste = value)
+    }
+    get() = style.allowCodePaste

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewStyleUtils.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewStyleUtils.kt
@@ -29,6 +29,7 @@ internal object SmsConfirmationViewStyleUtils {
                 codeLength = SmsConfirmationView.DEFAULT_CODE_LENGTH,
                 symbolsSpacing = resources.getDimensionPixelSize(R.dimen.symbols_spacing),
                 symbolViewStyle = symbolViewStyle,
+                allowCodePaste = true
             )
         }
         return defaultStyle!!
@@ -47,6 +48,10 @@ internal object SmsConfirmationViewStyleUtils {
         return with(typedArray) {
             val showCursor: Boolean = getBoolean(
                 R.styleable.SmsConfirmationView_scv_showCursor,
+                defaultSymbolStyle.showCursor
+            )
+            val allowCodePaste: Boolean = getBoolean(
+                R.styleable.SmsConfirmationView_scv_allowCodePaste,
                 defaultSymbolStyle.showCursor
             )
             val symbolWidth: Int = getDimensionPixelSize(
@@ -129,7 +134,8 @@ internal object SmsConfirmationViewStyleUtils {
                     textSize = symbolTextSize,
                     typeface = symbolTextFont
                 ),
-                smsDetectionMode = smsDetectionMode
+                smsDetectionMode = smsDetectionMode,
+                allowCodePaste = allowCodePaste
             )
         }
     }

--- a/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewStyleUtils.kt
+++ b/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationViewStyleUtils.kt
@@ -52,7 +52,7 @@ internal object SmsConfirmationViewStyleUtils {
             )
             val allowCodePaste: Boolean = getBoolean(
                 R.styleable.SmsConfirmationView_scv_allowCodePaste,
-                defaultSymbolStyle.showCursor
+                defaultStyle.allowCodePaste
             )
             val symbolWidth: Int = getDimensionPixelSize(
                 R.styleable.SmsConfirmationView_scv_symbolWidth,

--- a/library/src/main/res/menu/popup_menu_paste.xml
+++ b/library/src/main/res/menu/popup_menu_paste.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_item_paste"
+        android:title="@android:string/paste"/>
+</menu>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
             <enum name="manual" value="2" />
         </attr>
         <attr name="scv_symbolTextFont" format="reference"/>
+        <attr name="scv_allowCodePaste" format="boolean"/>
     </declare-styleable>
 
 </resources>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -15,6 +15,7 @@
         app:scv_codeLength="4"
         app:scv_showCursor="true"
         app:scv_smsDetectionMode="manual"
+        app:scv_allowCodePaste="true"
         app:scv_symbolBackgroundColor="@android:color/white"
         app:scv_symbolBorderActiveColor="?colorPrimary"
         app:scv_symbolBorderColor="@android:color/black"


### PR DESCRIPTION
# Why?
Functionality for pasting codes was not available, so I added it as well as an `attr` to enable/disable, enabled by default. Also added the ability to long-click and paste from the clipboard via menu item.

# Known Issues
Deprecation warning for [KeyEvent.ACTION_MULTIPLE](https://developer.android.com/reference/android/view/KeyEvent.html#ACTION_MULTIPLE) and its [event.characters](https://developer.android.com/reference/android/view/KeyEvent#getCharacters()), there doesn't seem to be a great explanation let alone an alternative. [See here.](https://github.com/BAbbottKlover/sms-confirmation-view/blob/fce63fc4479f17e02a62a58296deac3ee01317ba/library/src/main/java/com/fraggjkee/smsconfirmationview/SmsConfirmationView.kt#L165)

# Videos

| Samsung A12 (API 31) | Pixel 7 Pro (API 33) | Emulator-Popup-Paste (API 30) |
|--------|--------|--------|
| <video src="https://github.com/fraggjkee/sms-confirmation-view/assets/80705370/5e49cfbc-c5bf-4a71-9ab2-05bd2860f141"> | <video src="https://github.com/fraggjkee/sms-confirmation-view/assets/80705370/07da22ce-8281-46d9-b10d-055819c950a9"> | <video src="https://github.com/fraggjkee/sms-confirmation-view/assets/80705370/5ebe0571-498b-41f5-b235-1f79b89df7de">








